### PR TITLE
hotfix: fix cpu usage high cause by in loop to call <-time.Tick(xxx)

### DIFF
--- a/pkg/core/tunhandler.go
+++ b/pkg/core/tunhandler.go
@@ -143,11 +143,15 @@ func (h *tunHandler) Handle(ctx context.Context, tun net.Conn) {
 }
 
 func (h *tunHandler) printRoute(ctx context.Context) {
+	ticker := time.NewTicker(time.Second * 5)
+	defer ticker.Stop()
+	var sb strings.Builder
+	var i int
 	for ctx.Err() == nil {
 		select {
-		case <-time.Tick(time.Second * 5):
-			var i int
-			var sb strings.Builder
+		case <-ticker.C:
+			i = 0
+			sb.Reset()
 			h.routeNAT.Range(func(key string, value []net.Addr) {
 				i++
 				var s []string

--- a/pkg/handler/connect.go
+++ b/pkg/handler/connect.go
@@ -334,8 +334,10 @@ func (c *ConnectOptions) portForward(ctx context.Context, portPair []string) err
 			}()
 		}
 	}()
+	ticker := time.NewTicker(time.Second * 60)
+	defer ticker.Stop()
 	select {
-	case <-time.Tick(time.Second * 60):
+	case <-ticker.C:
 		return errors.New("port forward timeout")
 	case err := <-errChan:
 		return err

--- a/pkg/util/networkpolicy_windows.go
+++ b/pkg/util/networkpolicy_windows.go
@@ -16,11 +16,13 @@ import (
 
 // DeleteBlockFirewallRule Delete all action block firewall rule
 func DeleteBlockFirewallRule(ctx context.Context) {
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.Tick(time.Second * 10):
+		case <-ticker.C:
 			// PowerShell Remove-NetFirewallRule -Action Block
 			cmd := exec.Command("PowerShell", []string{
 				"Remove-NetFirewallRule",

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -299,6 +299,8 @@ func WaitPodToBeReady(ctx context.Context, podInterface v12.PodInterface, select
 	}
 	defer watchStream.Stop()
 	var last string
+	ticker := time.NewTicker(time.Minute * 60)
+	defer ticker.Stop()
 	for {
 		select {
 		case e, ok := <-watchStream.ResultChan():
@@ -328,7 +330,7 @@ func WaitPodToBeReady(ctx context.Context, podInterface v12.PodInterface, select
 				}
 				last = sb.String()
 			}
-		case <-time.Tick(time.Minute * 60):
+		case <-ticker.C:
 			return errors.New(fmt.Sprintf("wait pod to be ready timeout"))
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -207,11 +207,13 @@ func RunWithRollingOutWithChecker(cmd *osexec.Cmd, checker func(log string)) (st
 
 func WaitPortToBeFree(ctx context.Context, port int) error {
 	log.Infoln(fmt.Sprintf("wait port %v to be free...", port))
+	ticker := time.NewTicker(time.Second * 2)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("wait port %v to be free timeout", port)
-		case <-time.Tick(time.Second * 2):
+		case <-ticker.C:
 			if !IsPortListening(port) {
 				log.Infoln(fmt.Sprintf("port %v are free", port))
 				return nil


### PR DESCRIPTION
Resolve #197 