### PR TITLE
Fix panic when removing CIDRs containing API server IP addresses

### DIFF
--- a/pkg/handler/connect_test.go
+++ b/pkg/handler/connect_test.go
@@ -21,3 +21,131 @@ func TestRoute(t *testing.T) {
 	}
 	t.Logf("iface: %s, gateway: %s, src: %s", iface.Name, gateway, src)
 }
+
+func TestRemoveCIDRsContainingIPs(t *testing.T) {
+	tests := []struct {
+		name          string
+		cidrStrings   []string
+		ipStrings     []string
+		expectedCIDRs []string
+		expectPanic   bool
+	}{
+		{
+			name: "Normal case - some overlaps",
+			cidrStrings: []string{
+				"10.140.45.0/24", "10.140.44.0/24", "10.31.0.0/24", "10.31.1.0/24", "10.31.2.0/24", "10.31.3.0/24", "10.140.47.0/24", "10.140.46.0/24",
+			},
+			ipStrings: []string{
+				"10.140.45.1", "10.140.46.220", "10.140.45.180", "10.140.45.152",
+				"10.140.46.183", "10.140.45.52", "10.140.47.148", "10.140.46.214",
+			},
+			expectedCIDRs: []string{
+				"10.140.44.0/24", "10.31.0.0/24", "10.31.1.0/24", "10.31.2.0/24", "10.31.3.0/24",
+			},
+			expectPanic: false,
+		},
+		{
+			name:        "Empty CIDR list",
+			cidrStrings: []string{},
+			ipStrings: []string{
+				"10.140.45.1",
+			},
+			expectedCIDRs: []string{},
+			expectPanic:   false,
+		},
+		{
+			name: "Empty IP list",
+			cidrStrings: []string{
+				"10.140.45.0/24", "10.140.44.0/24",
+			},
+			ipStrings: []string{},
+			expectedCIDRs: []string{
+				"10.140.45.0/24", "10.140.44.0/24",
+			},
+			expectPanic: false,
+		},
+		{
+			name: "All CIDRs removed",
+			cidrStrings: []string{
+				"10.140.45.0/24", "10.140.46.0/24",
+			},
+			ipStrings: []string{
+				"10.140.45.1", "10.140.46.220",
+			},
+			expectedCIDRs: []string{},
+			expectPanic:   false,
+		},
+		{
+			name: "Overlapping CIDRs",
+			cidrStrings: []string{
+				"10.140.45.0/24", "10.140.45.0/25", "10.140.45.128/25",
+			},
+			ipStrings: []string{
+				"10.140.45.1", "10.140.45.129",
+			},
+			expectedCIDRs: []string{},
+			expectPanic:   false,
+		},
+		{
+			name: "Invalid CIDR format",
+			cidrStrings: []string{
+				"10.140.45.0/24", "invalid-cidr",
+			},
+			ipStrings: []string{
+				"10.140.45.1",
+			},
+			expectedCIDRs: nil, // Panic expected
+			expectPanic:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !test.expectPanic {
+						t.Errorf("unexpected panic: %v", r)
+					}
+				} else if test.expectPanic {
+					t.Errorf("expected panic but got none")
+				}
+			}()
+
+			var cidrs []*net.IPNet
+			for _, cidr := range test.cidrStrings {
+				_, ipNet, err := net.ParseCIDR(cidr)
+				if err != nil {
+					if test.expectPanic {
+						panic(err) // Имитация ситуации паники
+					}
+					t.Fatalf("failed to parse CIDR %s: %v", cidr, err)
+				}
+				cidrs = append(cidrs, ipNet)
+			}
+
+			var ipList []net.IP
+			for _, ip := range test.ipStrings {
+				parsedIP := net.ParseIP(ip)
+				if parsedIP == nil {
+					t.Fatalf("failed to parse IP %s", ip)
+				}
+				ipList = append(ipList, parsedIP)
+			}
+
+			c := &ConnectOptions{
+				cidrs: cidrs,
+			}
+			c.removeCIDRsContainingIPs(ipList)
+			if !test.expectPanic {
+				if len(c.cidrs) != len(test.expectedCIDRs) {
+					t.Fatalf("unexpected number of remaining CIDRs: got %d, want %d", len(c.cidrs), len(test.expectedCIDRs))
+				}
+				for i, cidr := range c.cidrs {
+					if cidr.String() != test.expectedCIDRs[i] {
+						t.Errorf("unexpected CIDR at index %d: got %s, want %s", i, cidr.String(), test.expectedCIDRs[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/handler/connect_test.go
+++ b/pkg/handler/connect_test.go
@@ -116,7 +116,7 @@ func TestRemoveCIDRsContainingIPs(t *testing.T) {
 				_, ipNet, err := net.ParseCIDR(cidr)
 				if err != nil {
 					if test.expectPanic {
-						panic(err) // Имитация ситуации паники
+						panic(err)
 					}
 					t.Fatalf("failed to parse CIDR %s: %v", cidr, err)
 				}


### PR DESCRIPTION
In some cases, CIDR ranges of cluster containers and nodes overlap (e.g., Huawei Cloud’s Cloud Native 2.0 Network Model). This causes the current loop removing CIDR blocks with cluster API server IPs to go out of bounds, resulting in a panic on first iteration

```go
	for i := 0; i < len(c.cidrs); i++ {
		for _, ip := range ipList {
			if c.cidrs[i].Contains(ip) {
				c.cidrs = append(c.cidrs[:i], c.cidrs[i+1:]...)
				i--
			}
		}
	}

```
Added tests for this case.
