### PR TITLE
hotfix: return system resolver for sending requests to kube-api

### DIFF
--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -40,6 +40,8 @@ func NewDHCPManager(client corev1.ConfigMapInterface, namespace string) *Manager
 // InitDHCP
 // TODO optimize dhcp, using mac address, ip and deadline as unit
 func (m *Manager) InitDHCP(ctx context.Context) error {
+	net.DefaultResolver.PreferGo = false
+
 	cm, err := m.client.Get(ctx, config.ConfigMapPodTrafficManager, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get configmap %s, err: %v", config.ConfigMapPodTrafficManager, err)


### PR DESCRIPTION
As a result of configuring the default resolver in this commit (https://github.com/kubenetworks/kubevpn/pull/357/commits/9dc03ed75bdd21a68b8abd4ce27e1317d57c5069), it became impossible to connect to the Kubernetes API using its internal domain name when accessing the cluster network through a VPN client that does not add the private DNS server to /etc/resolv.conf, such as Cisco AnyConnect.