### PR TITLE
hotfix: set recv/send buffer size 1024k for adding ip to route table on macos

### DIFF
--- a/pkg/tun/route_darwin.go
+++ b/pkg/tun/route_darwin.go
@@ -66,6 +66,14 @@ func withRouteSocket(f func(routeSocket int) error) error {
 	if err = unix.SetsockoptInt(routeSocket, unix.SOL_SOCKET, unix.SO_USELOOPBACK, 0); err != nil {
 		return err
 	}
+	// Set receive buffer size 1024k
+	if err = unix.SetsockoptInt(routeSocket, unix.SOL_SOCKET, unix.SO_RCVBUF, 1024*1024); err != nil {
+		return err
+	}
+	// Set send buffer size 1024k
+	if err = unix.SetsockoptInt(routeSocket, unix.SOL_SOCKET, unix.SO_SNDBUF, 1024*1024); err != nil {
+		return err
+	}
 	return f(routeSocket)
 }
 


### PR DESCRIPTION
## route ip+net: sysctl: no buffer space available

```text
Connected private safe tunnel
Connected private safe tunnel
Adding Pod IP and Service IP to route table...
Adding Pod IP and Service IP to route table...
Failed to read packet from tun device: route ip+net: sysctl: no buffer space available
Failed to read packet from tun device: route ip+net: sysctl: no buffer space available
Failed to get tun device: can not found any interface with IP [198.19.0.105]
Handling connection for 54905
Failed to get tun device: can not found any interface with IP [198.19.0.105]
Handling connection for 54905
Configuring DNS service...
Configuring DNS service...
Get DNS service IP from Pod...
Get DNS service IP from Pod...
Failed to add service IP to route table: route ip+net: no such network interface
Failed to add service IP to route table: route ip+net: no such network interface
Failed to add Pod IP to route table: route ip+net: no such network interface
Failed to add Pod IP to route table: route ip+net: no such network interface
```