### PR TITLE
hotfix: fix init dir permission deny

### DIFF
--- a/cmd/kubevpn/cmds/daemon.go
+++ b/cmd/kubevpn/cmds/daemon.go
@@ -41,6 +41,7 @@ func CmdDaemon(cmdutil.Factory) *cobra.Command {
 				_ = util.CleanupTempKubeConfigFile()
 			} else {
 				go util.StartupPProf(config.PProfPort)
+				config.Init()
 			}
 			return initLogfile(action.GetDaemonLogPath(opt.IsSudo))
 		},

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -29,7 +29,7 @@ const (
 //go:embed config.yaml
 var config []byte
 
-func init() {
+func Init() {
 	err := os.MkdirAll(DaemonPath, 0755)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
```shell
➜  ~ kubevpn upgrade
2025/05/06 23:48:27 INFO: Proxy settings detected
Current version is: v2.7.2 less than latest version: v2.7.3, needs to upgrade
Length: 28339137 (27.03M)
Writing temp file... 100% [=========================] (8.9 MB/s)
Upgrade daemon...
panic: chmod /Users/fengcaiwen/.kubevpn/tmp: operation not permitted

goroutine 1 [running]:
github.com/wencaiwulue/kubevpn/v2/pkg/config.init.1()
	/home/runner/work/kubevpn/kubevpn/pkg/config/const.go:63 +0x2f4


^C^C%
```