### PR TITLE
feat(handler): auto-detect SSH data-plane and bypass port-forward

### DIFF
--- a/docs/49-ssh-dataplane-bypass.md
+++ b/docs/49-ssh-dataplane-bypass.md
@@ -1,0 +1,105 @@
+# SSH Data-plane Bypass (Auto-detect)
+
+## Problem
+
+The standard data-plane path tunnels all VPN traffic through `kubectl port-forward`
+(SPDY/WebSocket via the Kubernetes API server). This has a well-documented instability
+problem: the port-forward session can "black-hole" — the local TCP connects and looks
+alive, but no data traverses (see [47-portforward-blackhole-liveness.md](47-portforward-blackhole-liveness.md)).
+
+When the user already connects through an SSH jump host (`--ssh-addr`), and that host
+happens to be a Kubernetes node, kube-proxy rules on the node make the traffic manager's
+ClusterIP directly reachable. We can tunnel the data plane through SSH instead, bypassing
+the API server entirely.
+
+## Design
+
+### Auto-detection (zero new flags)
+
+When `--ssh-addr` is provided, the root daemon automatically probes whether the SSH host
+can reach the traffic manager's ClusterIP:
+
+```
+NetworkManager.Start()
+  │
+  ├─ probeSSHDataPlane()
+  │    1. Get Service "kubevpn-traffic-manager" → ClusterIP
+  │    2. SSH dial → tcp://<ClusterIP>:10801 (3s timeout)
+  │    3. Success → return (clusterIP, true)
+  │       Failure → return ("", false)
+  │
+  ├─ [probe OK]  → sshForward()   — SSH tunnel for all 3 ports
+  └─ [probe fail] → portForward() — standard kubectl port-forward (unchanged)
+```
+
+No new CLI flags, no new proto fields. Bastion-only SSH hosts (not K8s nodes) fail the
+probe silently and fall back to port-forward — fully backward compatible.
+
+### Port forwarding via SSH
+
+`sshForward()` calls `ssh.PortMapUntil()` (existing helper in `pkg/ssh/ssh.go`) for each
+port pair. This establishes local TCP listeners that tunnel through the SSH connection to
+the traffic manager's ClusterIP:
+
+```
+127.0.0.1:<local1>  ──SSH──▶  <ClusterIP>:10801  (gvisor TCP data plane)
+127.0.0.1:<local2>  ──SSH──▶  <ClusterIP>:10802  (gvisor UDP-over-TCP data plane)
+127.0.0.1:<local3>  ──SSH──▶  <ClusterIP>:9002   (xDS gRPC control plane)
+```
+
+After the tunnels are established, the rest of the connect flow is unchanged: TUN dials
+`tcp://127.0.0.1:<local1>`, gRPC dials `127.0.0.1:<local3>`, heartbeat liveness works
+at the TUN layer regardless of the underlying transport.
+
+### Service port 10802
+
+Port 10802 (UDP-over-TCP) was previously only accessible via direct pod port-forward.
+It is now exposed on the `kubevpn-traffic-manager` Service as TCP so it is reachable via
+ClusterIP. This is required for SSH-mode and harmless for the standard port-forward path
+(which already forwarded to the pod directly).
+
+## Architecture comparison
+
+```
+Standard path (port-forward):
+  TUN ─▶ 127.0.0.1:<local> ─▶ [SPDY/WS via API server] ─▶ pod:10801
+
+SSH data-plane path:
+  TUN ─▶ 127.0.0.1:<local> ─▶ [SSH tunnel] ─▶ node ─▶ ClusterIP:10801 ─▶ pod:10801
+```
+
+| Aspect | port-forward | SSH data-plane |
+|---|---|---|
+| API server dependency | Yes (SPDY/WebSocket) | No |
+| Black-hole risk | Known issue | SSH TCP is reliable |
+| Reconnection | Client-side detect + retry | `PortMapUntil` auto-reconnects |
+| Pod restart handling | Must re-find pod | ClusterIP is stable; kube-proxy updates endpoints |
+| Requirement | kubeconfig access | SSH access to a K8s node |
+
+## Liveness
+
+- **Heartbeat watchdog** (`watchDataPlaneLiveness`): unchanged — operates at TUN layer
+- **Pod status watcher** (`CheckPodStatus`): not needed in SSH mode (ClusterIP is stable),
+  but the code path is simply not reached (SSH mode does not call `portForwardOnce`)
+- **SSH reconnection**: `PortMapUntil` internally reconnects SSH clients via `getRemoteConn`
+  with a `sync.Map`-based client pool
+
+## Code locations
+
+| Component | File | Function |
+|---|---|---|
+| Probe | `pkg/handler/network.go` | `probeSSHDataPlane()` |
+| SSH tunnel setup | `pkg/handler/network.go` | `sshForward()` |
+| Branch in Start() | `pkg/handler/network.go` | `Start()` |
+| SSH config threading | `pkg/handler/data_session.go` | `DataSession.SshConf` |
+| Root daemon wiring | `pkg/daemon/action/connect.go` | `Connect()` |
+| Service port 10802 | `pkg/handler/traffmgr_resources.go` | `genService()` |
+| Port name constant | `pkg/config/config.go` | `PortNameUDP` |
+| SSH port forwarding | `pkg/ssh/ssh.go` | `PortMapUntil()` |
+
+## Related docs
+
+- [15-ssh-architecture.md](15-ssh-architecture.md) — SSH subsystem overview
+- [47-portforward-blackhole-liveness.md](47-portforward-blackhole-liveness.md) — port-forward instability
+- [24-traffic-manager-deployment.md](24-traffic-manager-deployment.md) — traffic manager resources
+- [02-dual-daemon.md](02-dual-daemon.md) — user daemon vs root daemon

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,6 +70,8 @@ const (
 	PortNameDNS = "53-for-dns"
 	// PortDNS is the traffic-manager DNS service port number.
 	PortDNS = 53
+	// PortNameUDP is the traffic-manager service port name for UDP tunneling (over TCP).
+	PortNameUDP = "10802-for-udp"
 	// PortUDP is the traffic-manager UDP tunnel port number.
 	PortUDP = 10802
 	// PortSSH is the traffic-manager SSH tunnel port number (service/fargate mode and reverse tunnel).

--- a/pkg/daemon/action/connect.go
+++ b/pkg/daemon/action/connect.go
@@ -62,6 +62,7 @@ func (svr *Server) Connect(resp rpc.Daemon_ConnectServer) (err error) {
 		OwnerID:              req.OwnerID,
 		ConnectionID:         req.ConnectionID,
 		ReservedTunIPs:       svr.siblingTunIPs,
+		SshConf:              parseSshFromRPC(req.SshJump),
 	}
 	session := NewSessionLifecycle(logger)
 	ds.AddRollbackFunc(func() error {

--- a/pkg/handler/data_session.go
+++ b/pkg/handler/data_session.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wencaiwulue/kubevpn/v2/pkg/config"
 	"github.com/wencaiwulue/kubevpn/v2/pkg/dns"
 	plog "github.com/wencaiwulue/kubevpn/v2/pkg/log"
+	"github.com/wencaiwulue/kubevpn/v2/pkg/ssh"
 	"github.com/wencaiwulue/kubevpn/v2/pkg/util"
 )
 
@@ -43,6 +44,7 @@ type DataSession struct {
 	// Lock is from &svr.Lock (DNS shared lock), not from the request proto.
 	Lock           *sync.Mutex
 	ReservedTunIPs func() []net.IP
+	SshConf        *ssh.SshConfig
 
 	// Data-plane lifecycle: set at the START of DoConnect.
 	// nil before DoConnect is called (should never occur in practice —
@@ -103,6 +105,7 @@ func (ds *DataSession) DoConnect(ctx context.Context) (err error) {
 		Hostname:          hostname,
 		GetRunningPodList: ds.GetRunningPodList,
 		ReservedTunIPs:    ds.ReservedTunIPs,
+		SshConf:           ds.SshConf,
 	})
 	if err = ds.nm.Start(ds.ctx); err != nil {
 		return

--- a/pkg/handler/network.go
+++ b/pkg/handler/network.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"runtime"
 	"slices"
 	"sync"
@@ -32,6 +33,7 @@ import (
 	"github.com/wencaiwulue/kubevpn/v2/pkg/dns"
 	"github.com/wencaiwulue/kubevpn/v2/pkg/driver"
 	plog "github.com/wencaiwulue/kubevpn/v2/pkg/log"
+	"github.com/wencaiwulue/kubevpn/v2/pkg/ssh"
 	"github.com/wencaiwulue/kubevpn/v2/pkg/tun"
 	"github.com/wencaiwulue/kubevpn/v2/pkg/util"
 	netutil "github.com/wencaiwulue/kubevpn/v2/pkg/util/netutil"
@@ -59,6 +61,11 @@ type NetworkConfig struct {
 	// clusters) in the same daemon. They are excluded from this connection's
 	// allocation so two clusters don't assign the same local TUN IP. Optional.
 	ReservedTunIPs func() []net.IP
+
+	// SshConf, when non-nil, enables automatic SSH data-plane probe: if the SSH
+	// host can reach the traffic manager's ClusterIP, port forwarding is done via
+	// SSH tunnel instead of kubectl port-forward (bypassing the API server).
+	SshConf *ssh.SshConfig
 }
 
 // NetworkManager owns the full networking lifecycle: port-forward, TUN, routes, DNS.
@@ -184,8 +191,15 @@ func (nm *NetworkManager) Start(ctx context.Context) error {
 		fmt.Sprintf("%d:%d", controlPlanePort, config.PortXDS),
 	}
 
-	if err := nm.portForward(nm.ctx, portPair); err != nil {
-		return err
+	if clusterIP, ok := nm.probeSSHDataPlane(nm.ctx); ok {
+		plog.G(nm.ctx).Infof("SSH host can reach ClusterIP %s, using SSH tunnel for data plane", clusterIP)
+		if err := nm.sshForward(nm.ctx, clusterIP, portPair); err != nil {
+			return err
+		}
+	} else {
+		if err := nm.portForward(nm.ctx, portPair); err != nil {
+			return err
+		}
 	}
 	plog.StepDone(nm.ctx, "Forwarded ports (TCP/UDP/xDS)")
 
@@ -659,6 +673,64 @@ func nextPortForwardDelay(cur, sessionDuration time.Duration) time.Duration {
 		next = portForwardReconnectMaxDelay
 	}
 	return next
+}
+
+// probeSSHDataPlane checks whether the SSH host can reach the traffic manager's
+// ClusterIP directly (i.e., the SSH host is a K8s node with kube-proxy). Returns
+// the ClusterIP and true if reachable, ("", false) otherwise — the caller should
+// fall back to standard kubectl port-forward.
+func (nm *NetworkManager) probeSSHDataPlane(ctx context.Context) (string, bool) {
+	if nm.cfg.SshConf == nil || nm.cfg.SshConf.IsEmpty() {
+		return "", false
+	}
+	svc, err := nm.cfg.Clientset.CoreV1().Services(nm.cfg.ManagerNamespace).
+		Get(ctx, config.ConfigMapPodTrafficManager, metav1.GetOptions{})
+	if err != nil {
+		plog.G(ctx).Debugf("SSH data-plane probe: failed to get service: %v", err)
+		return "", false
+	}
+	clusterIP := svc.Spec.ClusterIP
+	if clusterIP == "" || clusterIP == "None" {
+		return "", false
+	}
+
+	client, err := ssh.DialSshRemote(ctx, nm.cfg.SshConf, ctx.Done())
+	if err != nil {
+		plog.G(ctx).Debugf("SSH data-plane probe: failed to dial SSH: %v", err)
+		return "", false
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	target := net.JoinHostPort(clusterIP, fmt.Sprintf("%d", config.PortTCP))
+	conn, err := client.DialContext(probeCtx, "tcp", target)
+	if err != nil {
+		plog.G(ctx).Debugf("SSH data-plane probe: SSH host cannot reach %s: %v", target, err)
+		client.Close()
+		return "", false
+	}
+	conn.Close()
+	client.Close()
+	return clusterIP, true
+}
+
+// sshForward sets up SSH tunnels from local ports to the traffic manager's ClusterIP
+// ports. Each portPair entry is "localPort:remotePort"; the remote side is reached
+// through the SSH host via clusterIP.
+func (nm *NetworkManager) sshForward(ctx context.Context, clusterIP string, portPairs []string) error {
+	for _, pair := range portPairs {
+		var localPort, remotePort int
+		if _, err := fmt.Sscanf(pair, "%d:%d", &localPort, &remotePort); err != nil {
+			return fmt.Errorf("invalid port pair %q: %w", pair, err)
+		}
+		local := netip.MustParseAddrPort(fmt.Sprintf("127.0.0.1:%d", localPort))
+		remote := netip.MustParseAddrPort(fmt.Sprintf("%s:%d", clusterIP, remotePort))
+		if err := ssh.PortMapUntil(ctx, nm.cfg.SshConf, remote, local); err != nil {
+			return fmt.Errorf("ssh forward %s -> %s: %w", local, remote, err)
+		}
+		plog.G(ctx).Infof("SSH tunnel: %s -> %s", local, remote)
+	}
+	return nil
 }
 
 // portForward sets up port-forwarding to the traffic manager pod with automatic

--- a/pkg/handler/once_test.go
+++ b/pkg/handler/once_test.go
@@ -144,8 +144,8 @@ func TestCreateOutboundPod(t *testing.T) {
 	if svc.Name != config.ConfigMapPodTrafficManager {
 		t.Fatalf("expected service name %q, got %q", config.ConfigMapPodTrafficManager, svc.Name)
 	}
-	if len(svc.Spec.Ports) != 3 {
-		t.Fatalf("expected 3 service ports, got %d", len(svc.Spec.Ports))
+	if len(svc.Spec.Ports) != 4 {
+		t.Fatalf("expected 4 service ports, got %d", len(svc.Spec.Ports))
 	}
 
 	// Verify Secret was created

--- a/pkg/handler/traffmgr_resources.go
+++ b/pkg/handler/traffmgr_resources.go
@@ -201,6 +201,7 @@ func genProxyClusterRoleBinding(saNamespace string) *rbacv1.ClusterRoleBinding {
 
 func genService(namespace string) *v1.Service {
 	tcp10801 := config.PortNameTCP
+	tcp10802 := config.PortNameUDP
 	tcp9002 := config.PortNameEnvoy
 	udp53 := config.PortNameDNS
 	return &v1.Service{
@@ -214,6 +215,11 @@ func genService(namespace string) *v1.Service {
 				Protocol:   v1.ProtocolTCP,
 				Port:       config.PortTCP,
 				TargetPort: intstr.FromInt32(config.PortTCP),
+			}, {
+				Name:       tcp10802,
+				Protocol:   v1.ProtocolTCP,
+				Port:       config.PortUDP,
+				TargetPort: intstr.FromInt32(config.PortUDP),
 			}, {
 				Name:       tcp9002,
 				Protocol:   v1.ProtocolTCP,

--- a/pkg/handler/traffmgr_test.go
+++ b/pkg/handler/traffmgr_test.go
@@ -132,9 +132,9 @@ func TestGenService(t *testing.T) {
 		t.Fatalf("expected selector app=%q, got %q", config.ConfigMapPodTrafficManager, svc.Spec.Selector["app"])
 	}
 
-	// 3 ports
-	if len(svc.Spec.Ports) != 3 {
-		t.Fatalf("expected 3 ports, got %d", len(svc.Spec.Ports))
+	// 4 ports: TCP 10801, TCP 10802, TCP 9002, UDP 53
+	if len(svc.Spec.Ports) != 4 {
+		t.Fatalf("expected 4 ports, got %d", len(svc.Spec.Ports))
 	}
 
 	type portCase struct {
@@ -144,6 +144,7 @@ func TestGenService(t *testing.T) {
 	}
 	expected := []portCase{
 		{config.PortNameTCP, 10801, v1.ProtocolTCP},
+		{config.PortNameUDP, 10802, v1.ProtocolTCP},
 		{config.PortNameEnvoy, 9002, v1.ProtocolTCP},
 		{config.PortNameDNS, 53, v1.ProtocolUDP},
 	}


### PR DESCRIPTION
When --ssh-addr points to a K8s node, automatically probe the traffic manager ClusterIP through the SSH tunnel. If reachable, forward ports via SSH instead of kubectl port-forward, eliminating API server dependency for the data plane. Falls back to port-forward when the SSH host cannot reach the ClusterIP (e.g. bastion-only jump host).

Also expose port 10802 (UDP-over-TCP) on the traffic manager Service so all data-plane ports are reachable via ClusterIP.